### PR TITLE
Remove geoip from main php.ini

### DIFF
--- a/apache/php.ini
+++ b/apache/php.ini
@@ -1,4 +1,3 @@
 always_populate_raw_post_data=-1
-extension=geoip.so
 geoip.custom_directory=/var/www/html/misc
 display_errors=Off

--- a/fpm/php.ini
+++ b/fpm/php.ini
@@ -1,4 +1,3 @@
 always_populate_raw_post_data=-1
-extension=geoip.so
 geoip.custom_directory=/var/www/html/misc
 display_errors=Off


### PR DESCRIPTION
This fixes #85

Duplicate loading of a PHP extension issues a warning which can disturb expected output from PHP called on CLI level, such as Matomo's cron.

The geoip extension is still loaded via conf.d/docker-php-ext-geoip.ini. This file is created by docker-php-ext-enable during docker build.