### PR TITLE
adds docker-compose example and info to import logs

### DIFF
--- a/.examples/docker-compose.yml
+++ b/.examples/docker-compose.yml
@@ -1,0 +1,26 @@
+db:
+  image: mariadb:latest
+  volumes:
+    - ./mysql/runtime2:/var/lib/mysql
+  environment:
+    - MYSQL_ROOT_PASSWORD
+app:
+  image: piwik:fpm
+  links:
+    - db
+  volumes:
+    - ./config:/var/www/html/config:rw
+    - /home/your-logs-folder:/var/www/html/logs
+  env_file:
+    - ./matomo.env
+web:
+  image: nginx
+  volumes:
+    - ./nginx.conf:/etc/nginx/nginx.conf:ro
+  links:
+    - app
+  volumes_from:
+    - app
+  environment:
+    - VIRTUAL_HOST
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ And leave the rest as default.
 
 Then you can continue the installation with the super user.
 
+## Docker-composer examples and log import instructions
+
+A minimal set-up using docker-compose is available in the [.examples folder](.examples/docker-compose.yml), a more complete [example can be found at IndieHosters/piwik](https://github.com/libresh/compose-matomo/blob/master/docker-compose.yml).
+
+If you want to use the import logs script, you can then run the following container as needed, in order to execute the python import logs script:
+```
+docker run --rm --volumes-from="matomo_app_1" --link matomo_app_1 python:2-alpine python /var/www/html/misc/log-analytics/import_logs.py --url=http://ip.of.your.piwik --login=yourlogin --password=yourpassword --idsite=1 --recorders=4 /var/www/html/logs/access.log
+```
+
 ## Contribute
 
 Pull requests are very welcome!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matomo (formerly Piwik)
 
 [![Build Status](https://travis-ci.org/matomo-org/docker.svg?branch=master)](https://travis-ci.org/matomo-org/docker)
-
+<img align="right" width="300px" src="https://matomo.org/wp-content/themes/website-child/assets/img/media/matomo.png" alt="Matomo logo">
 [Matomo](https://matomo.org/) (formerly Piwik) is the leading open-source analytics platform that gives you more than just powerful analytics:
 
 - Free open-source software
@@ -9,8 +9,6 @@
 - User privacy protection
 - User-centric insights
 - Customisable and extensible
-
-![logo](https://matomo.org/wp-content/uploads/2018/01/matomo_logo_black_on_white.png)
 
 ## Usage
 


### PR DESCRIPTION
import logs with an external python container, and limits the logo size to make the page more readable.

Explanation based on @J0WI 's hint in #72  and on my first experiences with piwik in docker...