### PR TITLE
Add python2.7 to the Dockerfile for easier use of import_logs.py

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -51,6 +51,9 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get install -y --no-install-recommends \
+		python2.7 \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV MATOMO_VERSION 3.4.0

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -52,8 +52,7 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	apt-get install -y --no-install-recommends \
-		python2.7 \
-	; \
+		python2.7 ; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV MATOMO_VERSION 3.4.0

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -52,7 +52,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	apt-get install -y --no-install-recommends \
-		python2.7 ; \
+		python2.7 \
+    ; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV MATOMO_VERSION 3.4.0

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -53,7 +53,7 @@ RUN set -ex; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	apt-get install -y --no-install-recommends \
 		python2.7 \
-    ; \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV MATOMO_VERSION 3.4.0


### PR DESCRIPTION
Hi guys,

Is it possible to take this small change which adds python2.7 to the image so that people who are parsing their log files can make easier use of the import_logs.py?

Kind regards,
Christian