### PR TITLE
Adjust gpg code to kill daemons, cutting down on race conditions

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -61,7 +61,8 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237; \
 	gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz; \
-	rm -r "$GNUPGHOME" piwik.tar.gz.asc; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" piwik.tar.gz.asc; \
 	tar -xzf piwik.tar.gz -C /usr/src/; \
 	rm piwik.tar.gz; \
 	apk del .fetch-deps

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -71,7 +71,8 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237; \
 	gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz; \
-	rm -r "$GNUPGHOME" piwik.tar.gz.asc; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" piwik.tar.gz.asc; \
 	tar -xzf piwik.tar.gz -C /usr/src/; \
 	rm piwik.tar.gz; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -71,7 +71,8 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237; \
 	gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz; \
-	rm -r "$GNUPGHOME" piwik.tar.gz.asc; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" piwik.tar.gz.asc; \
 	tar -xzf piwik.tar.gz -C /usr/src/; \
 	rm piwik.tar.gz; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -61,7 +61,8 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237; \
 	gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz; \
-	rm -r "$GNUPGHOME" piwik.tar.gz.asc; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" piwik.tar.gz.asc; \
 	tar -xzf piwik.tar.gz -C /usr/src/; \
 	rm piwik.tar.gz; \
 	apk del .fetch-deps

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -71,7 +71,8 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237; \
 	gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz; \
-	rm -r "$GNUPGHOME" piwik.tar.gz.asc; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" piwik.tar.gz.asc; \
 	tar -xzf piwik.tar.gz -C /usr/src/; \
 	rm piwik.tar.gz; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \


### PR DESCRIPTION
These usually exhibit as error messages like the following during "rm":

    rm: cannot remove '/tmp/tmp.xoG9Ugnpfz/S.gpg-agent.browser': No such file or directory

This was the root cause behind #102/#104.

(See https://doi-janky.infosiftr.net/job/multiarch/job/amd64/job/matomo/.)