### PR TITLE
Possible fix for directory permission issues on 3.8.1 upgrade (issue #141)

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 if [ ! -e piwik.php ]; then
 	tar cf - --one-file-system -C /usr/src/piwik . | tar xf -
-	chown -R www-data .
 fi
+
+chown -R www-data .
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 if [ ! -e piwik.php ]; then
 	tar cf - --one-file-system -C /usr/src/piwik . | tar xf -
-	chown -R www-data .
 fi
+
+chown -R www-data .
 
 exec "$@"

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 if [ ! -e piwik.php ]; then
 	tar cf - --one-file-system -C /usr/src/piwik . | tar xf -
-	chown -R www-data .
 fi
+
+chown -R www-data .
 
 exec "$@"

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 if [ ! -e piwik.php ]; then
 	tar cf - --one-file-system -C /usr/src/piwik . | tar xf -
-	chown -R www-data .
 fi
+
+chown -R www-data .
 
 exec "$@"


### PR DESCRIPTION
A possible fix for the permissions error on /var/www/html when upgrading to 3.8.1 as explained in issue #141. This will unconditionally force www-data's ownership of the directory on the creation of the container which for some reason stopped happening automatically.

<img width="815" alt="screen shot 2019-01-29 at 9 33 35 am" src="https://user-images.githubusercontent.com/1703673/51915377-f85f8c00-23a8-11e9-824f-e35c5d1f8671.png">
