### PR TITLE
Added environment variables plugin to image

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -78,10 +78,11 @@ RUN set -ex; \
 	rm -rf GeoIPCity*
 
 RUN set -ex; \
-	curl -fsSL -o EnvironmentVariables.tar.gz \
-		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
-	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
-	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	apk add --no-cache --virtual .fetch-deps unzip; \
+	curl -fsSL -o EnvironmentVariables.zip \
+		"https://plugins.matomo.org/api/2.0/plugins/EnvironmentVariables/download/latest"; \
+	unzip EnvironmentVariables.zip -d /usr/src/piwik/plugins; \
+	apk del .fetch-deps; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
 COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -84,6 +84,8 @@ RUN set -ex; \
 	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
+COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -77,6 +77,13 @@ RUN set -ex; \
 	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/piwik/misc/GeoLite2-City.mmdb; \
 	rm -rf GeoIPCity*
 
+RUN set -ex; \
+	curl -fsSL -o EnvironmentVariables.tar.gz \
+		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
+	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
+	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -88,6 +88,13 @@ RUN set -ex; \
 	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/piwik/misc/GeoLite2-City.mmdb; \
 	rm -rf GeoIPCity*
 
+RUN set -ex; \
+	curl -fsSL -o EnvironmentVariables.tar.gz \
+		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
+	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
+	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -89,10 +89,12 @@ RUN set -ex; \
 	rm -rf GeoIPCity*
 
 RUN set -ex; \
-	curl -fsSL -o EnvironmentVariables.tar.gz \
-		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
-	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
-	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends unzip; \
+	curl -fsSL -o EnvironmentVariables.zip \
+		"https://plugins.matomo.org/api/2.0/plugins/EnvironmentVariables/download/latest"; \
+	unzip EnvironmentVariables.zip -d /usr/src/piwik/plugins; \
+	apt-get purge -y --auto-remove unzip; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
 COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -95,6 +95,8 @@ RUN set -ex; \
 	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
+COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -88,6 +88,13 @@ RUN set -ex; \
 	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/piwik/misc/GeoLite2-City.mmdb; \
 	rm -rf GeoIPCity*
 
+RUN set -ex; \
+	curl -fsSL -o EnvironmentVariables.tar.gz \
+		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
+	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
+	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -89,10 +89,12 @@ RUN set -ex; \
 	rm -rf GeoIPCity*
 
 RUN set -ex; \
-	curl -fsSL -o EnvironmentVariables.tar.gz \
-		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
-	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
-	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends unzip; \
+	curl -fsSL -o EnvironmentVariables.zip \
+		"https://plugins.matomo.org/api/2.0/plugins/EnvironmentVariables/download/latest"; \
+	unzip EnvironmentVariables.zip -d /usr/src/piwik/plugins; \
+	apt-get purge -y --auto-remove unzip; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
 COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -95,6 +95,8 @@ RUN set -ex; \
 	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
+COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/apache/common.config.ini.php
+++ b/apache/common.config.ini.php
@@ -1,0 +1,5 @@
+[Plugins]
+Plugins[] = EnvironmentVariables
+
+[PluginsInstalled]
+PluginsInstalled[] = EnvironmentVariables

--- a/common.config.ini.php
+++ b/common.config.ini.php
@@ -1,0 +1,5 @@
+[Plugins]
+Plugins[] = EnvironmentVariables
+
+[PluginsInstalled]
+PluginsInstalled[] = EnvironmentVariables

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -78,10 +78,11 @@ RUN set -ex; \
 	rm -rf GeoIPCity*
 
 RUN set -ex; \
-	curl -fsSL -o EnvironmentVariables.tar.gz \
-		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
-	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
-	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	apk add --no-cache --virtual .fetch-deps unzip; \
+	curl -fsSL -o EnvironmentVariables.zip \
+		"https://plugins.matomo.org/api/2.0/plugins/EnvironmentVariables/download/latest"; \
+	unzip EnvironmentVariables.zip -d /usr/src/piwik/plugins; \
+	apk del .fetch-deps; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
 COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -84,6 +84,8 @@ RUN set -ex; \
 	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
+COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -77,6 +77,13 @@ RUN set -ex; \
 	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/piwik/misc/GeoLite2-City.mmdb; \
 	rm -rf GeoIPCity*
 
+RUN set -ex; \
+	curl -fsSL -o EnvironmentVariables.tar.gz \
+		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
+	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
+	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/fpm-alpine/common.config.ini.php
+++ b/fpm-alpine/common.config.ini.php
@@ -1,0 +1,5 @@
+[Plugins]
+Plugins[] = EnvironmentVariables
+
+[PluginsInstalled]
+PluginsInstalled[] = EnvironmentVariables

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -88,6 +88,13 @@ RUN set -ex; \
 	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/piwik/misc/GeoLite2-City.mmdb; \
 	rm -rf GeoIPCity*
 
+RUN set -ex; \
+	curl -fsSL -o EnvironmentVariables.tar.gz \
+		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
+	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
+	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -89,10 +89,12 @@ RUN set -ex; \
 	rm -rf GeoIPCity*
 
 RUN set -ex; \
-	curl -fsSL -o EnvironmentVariables.tar.gz \
-		"https://github.com/matomo-org/plugin-EnvironmentVariables/archive/3.0.0.tar.gz"; \
-	mkdir /usr/src/piwik/plugins/EnvironmentVariables; \
-	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends unzip; \
+	curl -fsSL -o EnvironmentVariables.zip \
+		"https://plugins.matomo.org/api/2.0/plugins/EnvironmentVariables/download/latest"; \
+	unzip EnvironmentVariables.zip -d /usr/src/piwik/plugins; \
+	apt-get purge -y --auto-remove unzip; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
 COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -95,6 +95,8 @@ RUN set -ex; \
 	tar -xf EnvironmentVariables.tar.gz -C /usr/src/piwik/plugins/EnvironmentVariables --strip-components=1; \
 	rm /usr/src/piwik/plugins/EnvironmentVariables/CHANGELOG.md /usr/src/piwik/plugins/EnvironmentVariables/README.md;
 
+COPY common.config.ini.php /usr/src/piwik/config/common.config.ini.php
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")

--- a/fpm/common.config.ini.php
+++ b/fpm/common.config.ini.php
@@ -1,0 +1,5 @@
+[Plugins]
+Plugins[] = EnvironmentVariables
+
+[PluginsInstalled]
+PluginsInstalled[] = EnvironmentVariables

--- a/update.sh
+++ b/update.sh
@@ -27,6 +27,7 @@ for variant in apache fpm fpm-alpine; do
 	template="Dockerfile-${base[$variant]}.template"
 	cp $template "$variant/Dockerfile"
 	cp docker-entrypoint.sh "$variant/docker-entrypoint.sh"
+	cp common.config.ini.php "$variant/common.config.ini.php"
 	cp php.ini "$variant/php.ini"
 	sed -ri -e '
 		s/%%VARIANT%%/'"$variant"'/;


### PR DESCRIPTION
This pull request adds support for environment variables to used by matomo.
This way `docker run matomo -e MATOMO_DATABASE_HOST='mysql.server.com'` should set the server automatically for the configuration experience.
This supports the Azure offering CC @mattab 