### PR TITLE
Disable X-Powered-By PHP version header via expose_php flag

### DIFF
--- a/apache/php.ini
+++ b/apache/php.ini
@@ -1,3 +1,4 @@
 always_populate_raw_post_data=-1
 geoip.custom_directory=/var/www/html/misc
 display_errors=Off
+expose_php=Off

--- a/fpm-alpine/php.ini
+++ b/fpm-alpine/php.ini
@@ -1,3 +1,4 @@
 always_populate_raw_post_data=-1
 geoip.custom_directory=/var/www/html/misc
 display_errors=Off
+expose_php=Off

--- a/fpm/php.ini
+++ b/fpm/php.ini
@@ -1,3 +1,4 @@
 always_populate_raw_post_data=-1
 geoip.custom_directory=/var/www/html/misc
 display_errors=Off
+expose_php=Off

--- a/php.ini
+++ b/php.ini
@@ -1,3 +1,4 @@
 always_populate_raw_post_data=-1
 geoip.custom_directory=/var/www/html/misc
 display_errors=Off
+expose_php=Off


### PR DESCRIPTION
Hello! This is a small change to the four `php.ini` files that would remove the `X-Powered-By` header, which publicly exposes the current PHP version we're including.

<img width="325" alt="Screen Shot 2019-09-04 at 12 06 40 PM" src="https://user-images.githubusercontent.com/1703673/64272230-eb8db280-cf0c-11e9-9444-751815dae86e.png">

Advertising this isn't a huge deal but it's arguably a small [security risk](http://phpsec.org/projects/phpsecinfo/tests/expose_php.html) if an exploit becomes available for an outdated Matomo instance, and disabling it in production is considered a good idea these days.

Thanks!