### PR TITLE
Support CORS preflight requests

### DIFF
--- a/.examples/nginx/matomo.conf
+++ b/.examples/nginx/matomo.conf
@@ -10,6 +10,26 @@ server {
 	index index.php;
 	try_files $uri $uri/ =404;
 
+	location / {
+		if ($request_method = 'OPTIONS') {
+			# add_header 'Access-Control-Allow-Origin' '*';
+			add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+			add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+			add_header 'Content-Type' 'text/plain; charset=utf-8';
+			return 204;
+		}
+		if ($request_method = 'POST') {
+			# add_header 'Access-Control-Allow-Origin' '*';
+			add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+			add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+		}
+		if ($request_method = 'GET') {
+			# add_header 'Access-Control-Allow-Origin' '*';
+			add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+			add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+		}
+	}
+
 	## only allow accessing the following php files
 	location ~ ^/(index|matomo|piwik|js/index|plugins/HeatmapSessionRecording/configs).php {
 		# regex to split $uri to $fastcgi_script_name and $fastcgi_path


### PR DESCRIPTION
See https://enable-cors.org/server_nginx.html

This PR fixes the failing CORS preflight requests which result in a `405` error.