### PR TITLE
Add alpine pkg "tzdata" to alpine Dockerfiles

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -14,6 +14,7 @@ RUN set -ex; \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
+		tzdata \
 	; \
 	\
 	docker-php-ext-configure gd --with-freetype --with-jpeg; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex; \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
+		tzdata \
 	; \
 	\
 	docker-php-ext-configure gd --with-freetype --with-jpeg; \


### PR DESCRIPTION
With the package "tzdata" installed on the alpine image it's easily possible to set the containers timezone by setting `TZ` environment variable (e.g. `TZ=Europe/Zurich`).