### PR TITLE
Add DBIP-City database

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -77,17 +77,12 @@ RUN set -ex; \
 
 COPY php.ini /usr/local/etc/php/conf.d/php-matomo.ini
 
-# https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
-#RUN set -ex; \
-#	curl -fsSL -o GeoIPCity.tar.gz \
-#		"https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz"; \
-#	curl -fsSL -o GeoIPCity.tar.gz.md5 \
-#		"https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz.md5"; \
-#	echo "$(cat GeoIPCity.tar.gz.md5)  GeoIPCity.tar.gz" | md5sum -c -; \
-#	mkdir /usr/src/GeoIPCity; \
-#	tar -xf GeoIPCity.tar.gz -C /usr/src/GeoIPCity --strip-components=1; \
-#	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/matomo/misc/GeoLite2-City.mmdb; \
-#	rm -rf GeoIPCity*
+RUN \
+  set -ex; \
+  curl -fsSL -o DBIP-City.mmdb.gz "https://download.db-ip.com/free/dbip-city-lite-2020-02.mmdb.gz"; \
+  gunzip DBIP-City.mmdb.gz; \
+  mv DBIP-City.mmdb /usr/src/matomo/misc/DBIP-City.mmdb; \
+  rm -rf DBIP-City*
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -88,17 +88,12 @@ RUN set -ex; \
 
 COPY php.ini /usr/local/etc/php/conf.d/php-matomo.ini
 
-# https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
-#RUN set -ex; \
-#	curl -fsSL -o GeoIPCity.tar.gz \
-#		"https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz"; \
-#	curl -fsSL -o GeoIPCity.tar.gz.md5 \
-#		"https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz.md5"; \
-#	echo "$(cat GeoIPCity.tar.gz.md5)  GeoIPCity.tar.gz" | md5sum -c -; \
-#	mkdir /usr/src/GeoIPCity; \
-#	tar -xf GeoIPCity.tar.gz -C /usr/src/GeoIPCity --strip-components=1; \
-#	mv /usr/src/GeoIPCity/GeoLite2-City.mmdb /usr/src/matomo/misc/GeoLite2-City.mmdb; \
-#	rm -rf GeoIPCity*
+RUN \
+  set -ex; \
+  curl -fsSL -o DBIP-City.mmdb.gz "https://download.db-ip.com/free/dbip-city-lite-2020-02.mmdb.gz"; \
+  gunzip DBIP-City.mmdb.gz; \
+  mv DBIP-City.mmdb /usr/src/matomo/misc/DBIP-City.mmdb; \
+  rm -rf DBIP-City*
 
 COPY docker-entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This database is suggested to use by the matomo UI. I don't know if it's legal to embed this library inside the docker image. Feedback is welcome.

We could also add a script which is automatically checking for new versions of this database.