### PR TITLE
Run container by unprivileged user and speed up container start

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -91,9 +91,26 @@ COPY php.ini /usr/local/etc/php/conf.d/php-matomo.ini
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
-# WORKDIR is /var/www/html (inherited via "FROM php")
-# "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
+ENV APACHE_DOCUMENT_ROOT /var/www/matomo
+WORKDIR ${APACHE_DOCUMENT_ROOT}
+
+RUN \
+  mv /usr/src/matomo/config /usr/src/config && \
+  mv /usr/src/matomo/plugins /usr/src/plugins && \
+  mv /usr/src/matomo/* ${APACHE_DOCUMENT_ROOT} && \
+# Fix permissions
+  chgrp -R 0 . && \
+  chmod -R 775 . && \
+# Fix apache config
+  sed -i 's/80/9000/g' /etc/apache2/ports.conf && \
+  sed -i 's/80/9000/g' /etc/apache2/sites-available/000-default.conf && \
+  sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf && \
+  sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+VOLUME ["/var/www/matomo/config", "/var/www/matomo/plugins"]
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]
+
+USER 1001
+EXPOSE 9000

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -102,9 +102,26 @@ COPY php.ini /usr/local/etc/php/conf.d/php-matomo.ini
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
-# WORKDIR is /var/www/html (inherited via "FROM php")
-# "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
+ENV APACHE_DOCUMENT_ROOT /var/www/matomo
+WORKDIR ${APACHE_DOCUMENT_ROOT}
+
+RUN \
+  mv /usr/src/matomo/config /usr/src/config && \
+  mv /usr/src/matomo/plugins /usr/src/plugins && \
+  mv /usr/src/matomo/* ${APACHE_DOCUMENT_ROOT} && \
+# Fix permissions
+  chgrp -R 0 . && \
+  chmod -R 775 . && \
+# Fix apache config
+  sed -i 's/80/9000/g' /etc/apache2/ports.conf && \
+  sed -i 's/80/9000/g' /etc/apache2/sites-available/000-default.conf && \
+  sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf && \
+  sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+VOLUME ["/var/www/matomo/config", "/var/www/matomo/plugins"]
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]
+
+USER 1001
+EXPOSE 9000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 set -e
 
-if [ ! -e matomo.php ]; then
-	tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
-	chown -R www-data .
+if [ ! -e "$APACHE_DOCUMENT_ROOT/config/global.ini.php" ]; then
+  ln -s /usr/src/config/* "$APACHE_DOCUMENT_ROOT/config"
+fi
+
+if [ ! \( -n "$(ls -A "$APACHE_DOCUMENT_ROOT/plugins")" \) ]; then
+  ln -s /usr/src/plugins/* "$APACHE_DOCUMENT_ROOT/plugins"
 fi
 
 exec "$@"


### PR DESCRIPTION
To run a container on OpenShift/OKD or Kubernetes with recommended security settings it's not allowed to run containers with root. Currently this container is built to run with root which makes it's not possible to use it with the recommended security settings.

My changes:
- **BREAKING**: The port is 9000 now because port 80 can only be used by the root user
- The container speed has improved because not all files will be copied on container start anymore. Instead just the configs and plugins will be symlinked to the volumes.
- Directory permission are fixed now to be used by the root group (all executing users in docker are member of the root group)