### PR TITLE
fix nginx example regex

### DIFF
--- a/.examples/nginx/matomo.conf
+++ b/.examples/nginx/matomo.conf
@@ -32,7 +32,7 @@ server {
 	}
 
 	## disable all access to the following directories
-	location ~ /(config|tmp|core|lang) {
+	location ~ ^/(config|tmp|core|lang) {
 		deny all;
 		return 403; # replace with 404 to not show these directories exist
 	}


### PR DESCRIPTION
must use ^ or otherwise that regex matches things like "languageselector"
and throws an HTTP 403 while trying to load some innocent js files