### PR TITLE
Fixing missing MySQL password

### DIFF
--- a/.examples/nginx/docker-compose.yml
+++ b/.examples/nginx/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - db:/var/lib/mysql
     environment:
-      - MYSQL_ROOT_PASSWORD=
+      - MYSQL_RANDOM_ROOT_PASSWORD=1
     env_file:
       - ./db.env
 


### PR DESCRIPTION
been getting this error
```
nginx_db_1 exited with code 1
db_1   | 2021-08-12 10:43:46+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
db_1   | 2021-08-12 10:43:46+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.6.4+maria~focal started.
db_1   | 2021-08-12 10:43:46+00:00 [ERROR] [Entrypoint]: Database is uninitialized and password option is not specified
db_1   | 	You need to specify one of MARIADB_ROOT_PASSWORD, MARIADB_ALLOW_EMPTY_ROOT_PASSWORD and MARIADB_RANDOM_ROOT_PASSWORD
```