### PR TITLE
Add "file_env" support, especially for Docker secrets

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -1,6 +1,33 @@
 #!/bin/sh
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+# See https://github.com/MariaDB/mariadb-docker/commit/6452a881b90283f46c88925b08c2d580a49a27cc
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'MATOMO_DATABASE_HOST'
+file_env 'MATOMO_DATABASE_USERNAME'
+file_env 'MATOMO_DATABASE_PASSWORD'
+file_env 'MATOMO_DATABASE_DBNAME'
+
 if [ ! -e matomo.php ]; then
 	tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
 	chown -R www-data:www-data .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,33 @@
 #!/bin/sh
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+# See https://github.com/MariaDB/mariadb-docker/commit/6452a881b90283f46c88925b08c2d580a49a27cc
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'MATOMO_DATABASE_HOST'
+file_env 'MATOMO_DATABASE_USERNAME'
+file_env 'MATOMO_DATABASE_PASSWORD'
+file_env 'MATOMO_DATABASE_DBNAME'
+
 if [ ! -e matomo.php ]; then
 	tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
 	chown -R www-data:www-data .

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -1,6 +1,33 @@
 #!/bin/sh
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+# See https://github.com/MariaDB/mariadb-docker/commit/6452a881b90283f46c88925b08c2d580a49a27cc
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'MATOMO_DATABASE_HOST'
+file_env 'MATOMO_DATABASE_USERNAME'
+file_env 'MATOMO_DATABASE_PASSWORD'
+file_env 'MATOMO_DATABASE_DBNAME'
+
 if [ ! -e matomo.php ]; then
 	tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
 	chown -R www-data:www-data .

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -1,6 +1,33 @@
 #!/bin/sh
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+# See https://github.com/MariaDB/mariadb-docker/commit/6452a881b90283f46c88925b08c2d580a49a27cc
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'MATOMO_DATABASE_HOST'
+file_env 'MATOMO_DATABASE_USERNAME'
+file_env 'MATOMO_DATABASE_PASSWORD'
+file_env 'MATOMO_DATABASE_DBNAME'
+
 if [ ! -e matomo.php ]; then
 	tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
 	chown -R www-data:www-data .


### PR DESCRIPTION
This adds explicit support for the following Matomo environment variables:

- `MATOMO_DATABASE_HOST_FILE`
- `MATOMO_DATABASE_USERNAME_FILE`
- `MATOMO_DATABASE_PASSWORD_FILE`
- `MATOMO_DATABASE_DBNAME_FILE`

See https://github.com/MariaDB/mariadb-docker/commit/6452a881b90283f46c88925b08c2d580a49a27cc for an equivalent commit on the MariaDB docker entrypoint.

This should fix issue #214.

Co-authored-by: Tianon Gravi <tianon@users.noreply.github.com>


