### PR TITLE
run security file creation on apache launch

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,4 +56,6 @@ if [ ! -e matomo.php ]; then
 	chown -R "$user":"$group" .
 fi
 
+/var/www/html/console core:create-security-files
+
 exec "$@"


### PR DESCRIPTION
I encounter this warning with running from this container:

<img width="1435" alt="System_Check_-_Administration_-_Matomo" src="https://github.com/user-attachments/assets/8d0bfe29-dccc-4b6a-a788-bb0657824d3f">

Following [these instructions](https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-private-directories-are-accessible/?mtm_campaign=Matomo_App&mtm_source=Matomo_App_OnPremise&mtm_medium=App.Installation.systemCheckPage), I can make the error go away, but I am not mounting a volume on some of those directories, so the warning emerges on the next container execution.