### PR TITLE
Use depends_on instead of link in Compose file

### DIFF
--- a/.examples/nginx/docker-compose.yml
+++ b/.examples/nginx/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   app:
     image: matomo:fpm-alpine
     restart: always
-    links:
+    depends_on:
       - db
     volumes:
       # - ./config:/var/www/html/config:z


### PR DESCRIPTION
> Links allow you to define extra aliases by which a service is reachable from another service.

Source: https://docs.docker.com/compose/how-tos/networking/#link-containers

db hostname is define by default.

Instead we can use depends_on to control the order of service startup and shutdown.

Source: https://docs.docker.com/reference/compose-file/services/#depends_on