### PR TITLE
Set "org.opencontainers.image.source" Docker label

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,7 @@
 FROM php:8.4-%%VARIANT%%
 
+LABEL org.opencontainers.image.source="https://github.com/matomo-org/matomo"
+
 ENV PHP_MEMORY_LIMIT=256M
 
 RUN set -ex; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,5 +1,7 @@
 FROM php:8.4-%%VARIANT%%
 
+LABEL org.opencontainers.image.source="https://github.com/matomo-org/matomo"
+
 ENV PHP_MEMORY_LIMIT=256M
 
 RUN set -ex; \


### PR DESCRIPTION
This label can be used by Renovate to show the Matomo changelog for "matomo" Docker image updates.

See https://docs.renovatebot.com/modules/datasource/docker/


